### PR TITLE
Fix cluster-proxy memory leak by pooling proxied transports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	open-cluster-management.io/api v1.2.0
 	open-cluster-management.io/managed-serviceaccount v0.9.0
 	open-cluster-management.io/sdk-go v1.2.0
-	sigs.k8s.io/apiserver-network-proxy v0.34.0
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2
 	sigs.k8s.io/apiserver-runtime v1.1.1
 	sigs.k8s.io/controller-runtime v0.22.4

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,6 @@ open-cluster-management.io/managed-serviceaccount v0.9.0 h1:YK2AwVyjDF3IJGv48+Nc
 open-cluster-management.io/managed-serviceaccount v0.9.0/go.mod h1:q/pASWYWNEz3AodqKWphmMvK0IdmlWYltwDicjYBizs=
 open-cluster-management.io/sdk-go v1.2.0 h1:O9LCOoy5JfgK3k4e2OCBY2ZoCqBEwLbEWClqP01FkQI=
 open-cluster-management.io/sdk-go v1.2.0/go.mod h1:OHM74Kw1gh9RHxg7QjJlGXCDlPm7x2CtCkejHSdczs4=
-sigs.k8s.io/apiserver-network-proxy v0.34.0 h1:6u4x2V71KNHGD7x4Gl20/DH8o8HCskcySfgU1iGemVk=
-sigs.k8s.io/apiserver-network-proxy v0.34.0/go.mod h1:b6SA51XinSmfALGvbUxbA7R9D5E7mAtaVhzBQCOj03M=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 h1:jpcvIRr3GLoUoEKRkHKSmGjxb6lWwrBlJsXc+eUYQHM=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 h1:gBQPwqORJ8d8/YNZWEjoZs7npUVDpVXUUOFfW6CgAqE=

--- a/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
@@ -264,7 +264,7 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		cfg.Impersonate = p.getImpersonationConfig(request)
 	}
 
-	rt, err := restclient.TransportFor(cfg)
+	rt, err := proxyTransportFor(cfg, cluster)
 	if err != nil {
 		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating cluster proxy client %s", cluster.Name))
 		return
@@ -297,9 +297,15 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating upgrader client %s", cluster.Name))
 		return
 	}
+	upgradeDial := cfg.Dial
+	if cluster.Spec.Access.Endpoint.Type == ClusterEndpointTypeClusterProxy {
+		if holder, herr := ClusterProxyDialHolder(); herr == nil && holder != nil {
+			upgradeDial = holder.Dial
+		}
+	}
 	upgrading := utilnet.SetOldTransportDefaults(&http.Transport{
 		TLSClientConfig: tlsConfig,
-		DialContext:     cfg.Dial,
+		DialContext:     upgradeDial,
 	})
 	proxy.UpgradeTransport = apiproxy.NewUpgradeRequestRoundTripper(
 		upgrading,
@@ -313,6 +319,24 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		p.responder.Error(err)
 	})
 	proxy.ServeHTTP(writer, newReq)
+}
+
+// proxyTransportFor returns the round tripper used to proxy a request. For the
+// cluster-proxy endpoint it injects the shared DialHolder so the transport is pooled.
+func proxyTransportFor(cfg *restclient.Config, cluster *ClusterGateway) (http.RoundTripper, error) {
+	if cluster.Spec.Access.Endpoint.Type != ClusterEndpointTypeClusterProxy {
+		return restclient.TransportFor(cfg)
+	}
+	holder, err := ClusterProxyDialHolder()
+	if err != nil || holder == nil {
+		return restclient.TransportFor(cfg)
+	}
+	transportCfg, err := cfg.TransportConfig()
+	if err != nil {
+		return nil, err
+	}
+	transportCfg.DialHolder = holder
+	return transport.New(transportCfg)
 }
 
 type noSuppressPanicError struct{}

--- a/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
@@ -270,8 +270,11 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	// Resolve the shared cluster-proxy dial holder once and fail closed if it is
-	// unavailable; both the proxied transport and the upgrade transport use it.
+	// Both the proxied transport and the upgrade transport need the shared
+	// cluster-proxy DialHolder pointer (the proxied path injects it as the
+	// transport-cache key, the upgrade path uses its Dial). ClusterProxyDialHolder
+	// is memoized and NewConfigFromCluster already resolved it above, so this
+	// returns the cached holder; the error branch is a defensive fail-closed guard.
 	var dialHolder *transport.DialHolder
 	if cluster.Spec.Access.Endpoint.Type == ClusterEndpointTypeClusterProxy {
 		dialHolder, err = ClusterProxyDialHolder()

--- a/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
@@ -299,15 +299,20 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		return
 	}
 	upgradeDial := cfg.Dial
+	var upgrading http.RoundTripper
 	if cluster.Spec.Access.Endpoint.Type == ClusterEndpointTypeClusterProxy {
 		if holder, herr := ClusterProxyDialHolder(); herr == nil && holder != nil {
 			upgradeDial = holder.Dial
 		}
+		// Reuse one pooled upgrade transport per credential; otherwise it is
+		// rebuilt on every exec/attach/port-forward request.
+		upgrading = ClusterProxyUpgradeTransport(transportCfg, tlsConfig, upgradeDial)
+	} else {
+		upgrading = utilnet.SetOldTransportDefaults(&http.Transport{
+			TLSClientConfig: tlsConfig,
+			DialContext:     upgradeDial,
+		})
 	}
-	upgrading := utilnet.SetOldTransportDefaults(&http.Transport{
-		TLSClientConfig: tlsConfig,
-		DialContext:     upgradeDial,
-	})
 	proxy.UpgradeTransport = apiproxy.NewUpgradeRequestRoundTripper(
 		upgrading,
 		RoundTripperFunc(func(req *http.Request) (*http.Response, error) {

--- a/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
@@ -328,8 +328,11 @@ func proxyTransportFor(cfg *restclient.Config, cluster *ClusterGateway) (http.Ro
 		return restclient.TransportFor(cfg)
 	}
 	holder, err := ClusterProxyDialHolder()
-	if err != nil || holder == nil {
-		return restclient.TransportFor(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if holder == nil {
+		return nil, errors.New("cluster proxy dial holder is nil")
 	}
 	transportCfg, err := cfg.TransportConfig()
 	if err != nil {

--- a/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
@@ -279,10 +279,6 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 			responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed resolving cluster proxy dial holder %s", cluster.Name))
 			return
 		}
-		if dialHolder == nil {
-			responsewriters.InternalError(writer, request, fmt.Errorf("cluster proxy dial holder is nil for cluster %s", cluster.Name))
-			return
-		}
 	}
 
 	rt, err := proxyTransportFor(transportCfg, dialHolder)

--- a/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
@@ -270,7 +270,22 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	rt, err := proxyTransportFor(transportCfg, cluster)
+	// Resolve the shared cluster-proxy dial holder once and fail closed if it is
+	// unavailable; both the proxied transport and the upgrade transport use it.
+	var dialHolder *transport.DialHolder
+	if cluster.Spec.Access.Endpoint.Type == ClusterEndpointTypeClusterProxy {
+		dialHolder, err = ClusterProxyDialHolder()
+		if err != nil {
+			responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed resolving cluster proxy dial holder %s", cluster.Name))
+			return
+		}
+		if dialHolder == nil {
+			responsewriters.InternalError(writer, request, fmt.Errorf("cluster proxy dial holder is nil for cluster %s", cluster.Name))
+			return
+		}
+	}
+
+	rt, err := proxyTransportFor(transportCfg, dialHolder)
 	if err != nil {
 		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating cluster proxy client %s", cluster.Name))
 		return
@@ -288,29 +303,32 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		nil)
 
 	const defaultFlushInterval = 200 * time.Millisecond
-	tlsConfig, err := transport.TLSConfigFor(transportCfg)
-	if err != nil {
-		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating tls config %s", cluster.Name))
-		return
-	}
 	upgrader, err := transport.HTTPWrappersForConfig(transportCfg, apiproxy.MirrorRequest)
 	if err != nil {
 		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating upgrader client %s", cluster.Name))
 		return
 	}
-	upgradeDial := cfg.Dial
 	var upgrading http.RoundTripper
-	if cluster.Spec.Access.Endpoint.Type == ClusterEndpointTypeClusterProxy {
-		if holder, herr := ClusterProxyDialHolder(); herr == nil && holder != nil {
-			upgradeDial = holder.Dial
-		}
-		// Reuse one pooled upgrade transport per credential; otherwise it is
+	if dialHolder != nil {
+		// Reuse one pooled upgrade transport per cluster; otherwise it is
 		// rebuilt on every exec/attach/port-forward request.
-		upgrading = ClusterProxyUpgradeTransport(transportCfg, tlsConfig, upgradeDial)
+		upgrading, err = ClusterProxyUpgradeTransport(cluster.Name, transportCfg, dialHolder.Dial)
+		if err != nil {
+			responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating upgrade transport %s", cluster.Name))
+			return
+		}
 	} else {
+		// Build the tls.Config only on this (non-pooled) path; the pooled path
+		// derives it lazily on a cache miss.
+		tlsConfig, terr := transport.TLSConfigFor(transportCfg)
+		if terr != nil {
+			responsewriters.InternalError(writer, request, errors.Wrapf(terr, "failed creating tls config %s", cluster.Name))
+			return
+		}
 		upgrading = utilnet.SetOldTransportDefaults(&http.Transport{
 			TLSClientConfig: tlsConfig,
-			DialContext:     upgradeDial,
+			DialContext:     cfg.Dial,
+			Proxy:           cfg.Proxy,
 		})
 	}
 	proxy.UpgradeTransport = apiproxy.NewUpgradeRequestRoundTripper(
@@ -327,20 +345,13 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 	proxy.ServeHTTP(writer, newReq)
 }
 
-// proxyTransportFor returns the round tripper used to proxy a request. For the
-// cluster-proxy endpoint it injects the shared DialHolder so the transport is pooled.
-func proxyTransportFor(transportCfg *transport.Config, cluster *ClusterGateway) (http.RoundTripper, error) {
-	if cluster.Spec.Access.Endpoint.Type != ClusterEndpointTypeClusterProxy {
-		return transport.New(transportCfg)
+// proxyTransportFor returns the round tripper used to proxy a request. When a
+// cluster-proxy dial holder is supplied it is injected so client-go's transport
+// cache pools one http.Transport per credential across requests.
+func proxyTransportFor(transportCfg *transport.Config, dialHolder *transport.DialHolder) (http.RoundTripper, error) {
+	if dialHolder != nil {
+		transportCfg.DialHolder = dialHolder
 	}
-	holder, err := ClusterProxyDialHolder()
-	if err != nil {
-		return nil, err
-	}
-	if holder == nil {
-		return nil, errors.New("cluster proxy dial holder is nil")
-	}
-	transportCfg.DialHolder = holder
 	return transport.New(transportCfg)
 }
 

--- a/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
+++ b/pkg/apis/gateway/v1alpha1/clustergateway_proxy.go
@@ -264,7 +264,13 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		cfg.Impersonate = p.getImpersonationConfig(request)
 	}
 
-	rt, err := proxyTransportFor(cfg, cluster)
+	transportCfg, err := cfg.TransportConfig()
+	if err != nil {
+		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating transport config %s", cluster.Name))
+		return
+	}
+
+	rt, err := proxyTransportFor(transportCfg, cluster)
 	if err != nil {
 		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating cluster proxy client %s", cluster.Name))
 		return
@@ -282,11 +288,6 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 		nil)
 
 	const defaultFlushInterval = 200 * time.Millisecond
-	transportCfg, err := cfg.TransportConfig()
-	if err != nil {
-		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating transport config %s", cluster.Name))
-		return
-	}
 	tlsConfig, err := transport.TLSConfigFor(transportCfg)
 	if err != nil {
 		responsewriters.InternalError(writer, request, errors.Wrapf(err, "failed creating tls config %s", cluster.Name))
@@ -323,9 +324,9 @@ func (p *proxyHandler) ServeHTTP(_writer http.ResponseWriter, request *http.Requ
 
 // proxyTransportFor returns the round tripper used to proxy a request. For the
 // cluster-proxy endpoint it injects the shared DialHolder so the transport is pooled.
-func proxyTransportFor(cfg *restclient.Config, cluster *ClusterGateway) (http.RoundTripper, error) {
+func proxyTransportFor(transportCfg *transport.Config, cluster *ClusterGateway) (http.RoundTripper, error) {
 	if cluster.Spec.Access.Endpoint.Type != ClusterEndpointTypeClusterProxy {
-		return restclient.TransportFor(cfg)
+		return transport.New(transportCfg)
 	}
 	holder, err := ClusterProxyDialHolder()
 	if err != nil {
@@ -333,10 +334,6 @@ func proxyTransportFor(cfg *restclient.Config, cluster *ClusterGateway) (http.Ro
 	}
 	if holder == nil {
 		return nil, errors.New("cluster proxy dial holder is nil")
-	}
-	transportCfg, err := cfg.TransportConfig()
-	if err != nil {
-		return nil, err
 	}
 	transportCfg.DialHolder = holder
 	return transport.New(transportCfg)

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -24,22 +24,28 @@ import (
 
 // DialerGetter returns a dialer that creates a konnectivity tunnel on demand,
 // scoped to context.Background() so the connection it backs can be pooled.
+//
+// The client TLS material is read once here (when the dialer is built) rather
+// than on every dial, so it does not sit on the connection hot path. As a
+// consequence a rotation of the cluster-proxy client cert/key requires a
+// process restart to take effect.
 var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
 	proxyAddress := net.JoinHostPort(config.ClusterProxyHost, strconv.Itoa(config.ClusterProxyPort))
+	tlsCfg, err := util.GetClientTLSConfig(
+		config.ClusterProxyCAFile,
+		config.ClusterProxyCertFile,
+		config.ClusterProxyKeyFile,
+		config.ClusterProxyHost,
+		nil)
+	if err != nil {
+		return nil, err
+	}
+	transportCreds := grpccredentials.NewTLS(tlsCfg)
 	return func(ctx context.Context, _, addr string) (net.Conn, error) {
-		tlsCfg, err := util.GetClientTLSConfig(
-			config.ClusterProxyCAFile,
-			config.ClusterProxyCertFile,
-			config.ClusterProxyKeyFile,
-			config.ClusterProxyHost,
-			nil)
-		if err != nil {
-			return nil, err
-		}
 		dialerTunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
 			context.Background(),
 			proxyAddress,
-			grpc.WithTransportCredentials(grpccredentials.NewTLS(tlsCfg)),
+			grpc.WithTransportCredentials(transportCreds),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Time: time.Second * 5,
 			}),

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -1,9 +1,11 @@
 package v1alpha1
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"crypto/x509"
 	"net"
 	"net/http"
 	"net/url"
@@ -20,44 +22,38 @@ import (
 	restclient "k8s.io/client-go/rest"
 	k8stransport "k8s.io/client-go/transport"
 	konnectivity "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
-	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
 
 	"github.com/kluster-manager/cluster-gateway/pkg/config"
 )
 
+// clusterProxyTLSReloadInterval bounds how often the cluster-proxy TLS material
+// is re-read from disk on the dial path.
+const clusterProxyTLSReloadInterval = 30 * time.Second
+
 // DialerGetter returns a dialer that creates a konnectivity tunnel on demand,
 // scoped to context.Background() so the connection it backs can be pooled.
 //
-// The client TLS material is read once here (when the dialer is built) rather
-// than on every dial, so it does not sit on the connection hot path. The client
-// cert/key are reloaded lazily through tls.Config.GetClientCertificate when the
-// files change, so a rotation of the cluster-proxy client cert/key is picked up
-// on the next tunnel without a process restart. (Rotation of the CA bundle still
-// requires a restart.)
+// The client cert/key and the CA bundle are reloaded from disk by content (not
+// mtime), at most once per clusterProxyTLSReloadInterval, so a rotation of any
+// of them is picked up on the next tunnel without a process restart, while the
+// read stays off the per-handshake hot path. A transient read error falls back
+// to the last good material so an in-flight rotation does not break dials.
 var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
 	proxyAddress := net.JoinHostPort(config.ClusterProxyHost, strconv.Itoa(config.ClusterProxyPort))
-	tlsCfg, err := util.GetClientTLSConfig(
+	reloader, err := newReloadingTLS(
 		config.ClusterProxyCAFile,
 		config.ClusterProxyCertFile,
 		config.ClusterProxyKeyFile,
 		config.ClusterProxyHost,
-		nil)
+	)
 	if err != nil {
 		return nil, err
 	}
-	// Reload the client cert/key on rotation instead of pinning the copy read
-	// above for the lifetime of the process.
-	if config.ClusterProxyCertFile != "" || config.ClusterProxyKeyFile != "" {
-		reloader := &reloadingClientCert{certFile: config.ClusterProxyCertFile, keyFile: config.ClusterProxyKeyFile}
-		tlsCfg.Certificates = nil
-		tlsCfg.GetClientCertificate = reloader.getClientCertificate
-	}
-	transportCreds := grpccredentials.NewTLS(tlsCfg)
 	return func(ctx context.Context, _, addr string) (net.Conn, error) {
 		dialerTunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
 			context.Background(),
 			proxyAddress,
-			grpc.WithTransportCredentials(transportCreds),
+			grpc.WithTransportCredentials(grpccredentials.NewTLS(reloader.tlsConfig())),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Time: time.Second * 5,
 			}),
@@ -69,40 +65,131 @@ var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
 	}, nil
 }
 
-// reloadingClientCert loads the cluster-proxy client cert/key from disk and
-// re-reads them when the files change, so cert rotation does not require a
-// process restart. tls.Config calls getClientCertificate once per handshake.
-type reloadingClientCert struct {
-	certFile, keyFile string
+// reloadingTLS reloads the cluster-proxy CA bundle and client cert/key from disk
+// and hands out a fresh *tls.Config for each new konnectivity tunnel, so both
+// client-cert and CA rotation are picked up without a process restart. It reads
+// the files at most once per reload interval and compares by content, and keeps
+// the last good material if a re-read transiently fails (e.g. the brief window
+// while a Kubernetes secret's ..data symlink is swapped). It mirrors the
+// semantics of client-go's dynamicClientCert/cachingCertificateLoader for a path
+// that feeds gRPC transport credentials rather than an http.Transport.
+type reloadingTLS struct {
+	caFile, certFile, keyFile, serverName string
 
-	mu      sync.Mutex
-	cert    *tls.Certificate
-	modCert time.Time
-	modKey  time.Time
+	mu        sync.Mutex
+	lastCheck time.Time
+	caPool    *x509.CertPool
+	caData    []byte
+	cert      *tls.Certificate
+	// onRotate, if set, is invoked (with mu held) when the cert or CA changes
+	// after the initial load — used to drop pooled connections on rotation.
+	onRotate func()
 }
 
-func (r *reloadingClientCert) getClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+func newReloadingTLS(caFile, certFile, keyFile, serverName string) (*reloadingTLS, error) {
+	r := &reloadingTLS{caFile: caFile, certFile: certFile, keyFile: keyFile, serverName: serverName}
+	// Load once up front so a misconfiguration fails fast at dialer-build time
+	// rather than on the first proxied request.
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if err := r.reloadLocked(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
 
-	certInfo, err := os.Stat(r.certFile)
-	if err != nil {
-		return nil, err
+// tlsConfig returns a fresh *tls.Config carrying the current CA pool and client
+// certificate, refreshing them from disk if the reload interval has elapsed.
+func (r *reloadingTLS) tlsConfig() *tls.Config {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if time.Since(r.lastCheck) >= clusterProxyTLSReloadInterval {
+		// Best effort: reloadLocked keeps the last good material on error.
+		_ = r.reloadLocked()
 	}
-	keyInfo, err := os.Stat(r.keyFile)
-	if err != nil {
-		return nil, err
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ServerName: r.serverName,
+		RootCAs:    r.caPool,
 	}
-	if r.cert == nil || certInfo.ModTime().After(r.modCert) || keyInfo.ModTime().After(r.modKey) {
-		cert, err := tls.LoadX509KeyPair(r.certFile, r.keyFile)
+	if r.cert != nil {
+		cfg.Certificates = []tls.Certificate{*r.cert}
+	}
+	return cfg
+}
+
+// reloadLocked re-reads the CA and cert/key files. Callers hold r.mu. On a read
+// error it returns the error but leaves the previously loaded material in place
+// (when any) so transient failures do not break dials; the initial load (when
+// nothing is cached yet) surfaces the error to the caller.
+func (r *reloadingTLS) reloadLocked() error {
+	r.lastCheck = time.Now()
+
+	caData := r.caData
+	caPool := r.caPool
+	if r.caFile != "" {
+		data, err := os.ReadFile(r.caFile)
 		if err != nil {
-			return nil, err
+			if r.caPool == nil {
+				return err
+			}
+			return nil
 		}
-		r.cert = &cert
-		r.modCert = certInfo.ModTime()
-		r.modKey = keyInfo.ModTime()
+		caData = data
 	}
-	return r.cert, nil
+
+	var cert *tls.Certificate
+	if r.certFile != "" || r.keyFile != "" {
+		loaded, err := tls.LoadX509KeyPair(r.certFile, r.keyFile)
+		if err != nil {
+			if r.cert == nil {
+				return err
+			}
+			return nil
+		}
+		cert = &loaded
+	}
+
+	caChanged := !bytes.Equal(caData, r.caData)
+	if caChanged {
+		pool := x509.NewCertPool()
+		if len(caData) > 0 && !pool.AppendCertsFromPEM(caData) {
+			if r.caPool == nil {
+				return errors.Errorf("failed to parse cluster-proxy CA bundle %s", r.caFile)
+			}
+			caChanged = false
+		} else {
+			caPool = pool
+		}
+	}
+
+	certChanged := !certsEqual(r.cert, cert)
+	had := r.caPool != nil || r.cert != nil
+
+	r.caData = caData
+	r.caPool = caPool
+	r.cert = cert
+
+	if had && (caChanged || certChanged) && r.onRotate != nil {
+		r.onRotate()
+	}
+	return nil
+}
+
+// certsEqual reports whether two client certificates carry the same leaf chain.
+func certsEqual(a, b *tls.Certificate) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if len(a.Certificate) != len(b.Certificate) {
+		return false
+	}
+	for i := range a.Certificate {
+		if !bytes.Equal(a.Certificate[i], b.Certificate[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 var (

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -90,18 +90,20 @@ type reloadingTLS struct {
 	caPool    *x509.CertPool
 	caData    []byte
 	cert      *tls.Certificate
-	// onRotate, if set, is invoked (with mu held) when the cert or CA changes
-	// after the initial load — used to drop pooled connections on rotation.
+	// onRotate, if set, is invoked (without r.mu held) when the cert or CA
+	// changes after the initial load — used to drop pooled connections on
+	// rotation.
 	onRotate func()
 }
 
 func newReloadingTLS(caFile, certFile, keyFile, serverName string) (*reloadingTLS, error) {
 	r := &reloadingTLS{caFile: caFile, certFile: certFile, keyFile: keyFile, serverName: serverName}
 	// Load once up front so a misconfiguration fails fast at dialer-build time
-	// rather than on the first proxied request.
+	// rather than on the first proxied request. onRotate is not wired yet, so the
+	// initial load (which "changes" material from nothing) never fires it.
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if err := r.reloadLocked(); err != nil {
+	if _, err := r.reloadLocked(); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -111,10 +113,10 @@ func newReloadingTLS(caFile, certFile, keyFile, serverName string) (*reloadingTL
 // certificate, refreshing them from disk if the reload interval has elapsed.
 func (r *reloadingTLS) tlsConfig() *tls.Config {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	rotated := false
 	if time.Since(r.lastCheck) >= clusterProxyTLSReloadInterval {
 		// Best effort: reloadLocked keeps the last good material on error.
-		_ = r.reloadLocked()
+		rotated, _ = r.reloadLocked()
 	}
 	cfg := &tls.Config{
 		MinVersion: tls.VersionTLS12,
@@ -123,6 +125,14 @@ func (r *reloadingTLS) tlsConfig() *tls.Config {
 	}
 	if r.cert != nil {
 		cfg.Certificates = []tls.Certificate{*r.cert}
+	}
+	onRotate := r.onRotate
+	r.mu.Unlock()
+
+	// Drop pooled connections outside the lock so a slow close cannot stall
+	// concurrent dials.
+	if rotated && onRotate != nil {
+		onRotate()
 	}
 	return cfg
 }
@@ -135,62 +145,54 @@ func (r *reloadingTLS) setOnRotate(fn func()) {
 	r.mu.Unlock()
 }
 
-// reloadLocked re-reads the CA and cert/key files. Callers hold r.mu. On a read
-// error it returns the error but leaves the previously loaded material in place
-// (when any) so transient failures do not break dials; the initial load (when
-// nothing is cached yet) surfaces the error to the caller.
-func (r *reloadingTLS) reloadLocked() error {
+// reloadLocked re-reads the CA and cert/key files, updating each independently.
+// Callers hold r.mu. It reports whether the cert or CA content actually changed,
+// so the caller can drop pooled connections after releasing the lock. A read or
+// parse error leaves that component's last good material in place (and does not
+// cache unparseable bytes) so a transient failure — e.g. the brief window while a
+// Kubernetes secret's ..data symlink is swapped — does not break dials; the
+// initial load (nothing cached yet) surfaces the error to the caller.
+func (r *reloadingTLS) reloadLocked() (rotated bool, err error) {
 	r.lastCheck = time.Now()
 
-	caData := r.caData
-	caPool := r.caPool
 	if r.caFile != "" {
-		data, err := os.ReadFile(r.caFile)
-		if err != nil {
+		data, rerr := os.ReadFile(r.caFile)
+		switch {
+		case rerr != nil:
 			if r.caPool == nil {
-				return err
+				return false, rerr
 			}
-			return nil
+			// keep the last good CA
+		case !bytes.Equal(data, r.caData):
+			pool := x509.NewCertPool()
+			if len(data) > 0 && !pool.AppendCertsFromPEM(data) {
+				if r.caPool == nil {
+					return false, errors.Errorf("failed to parse cluster-proxy CA bundle %s", r.caFile)
+				}
+				// keep the last good CA; do not cache the unparseable bytes
+			} else {
+				r.caData = data
+				r.caPool = pool
+				rotated = true
+			}
 		}
-		caData = data
 	}
 
-	var cert *tls.Certificate
 	if r.certFile != "" || r.keyFile != "" {
-		loaded, err := tls.LoadX509KeyPair(r.certFile, r.keyFile)
-		if err != nil {
+		loaded, lerr := tls.LoadX509KeyPair(r.certFile, r.keyFile)
+		switch {
+		case lerr != nil:
 			if r.cert == nil {
-				return err
+				return false, lerr
 			}
-			return nil
-		}
-		cert = &loaded
-	}
-
-	caChanged := !bytes.Equal(caData, r.caData)
-	if caChanged {
-		pool := x509.NewCertPool()
-		if len(caData) > 0 && !pool.AppendCertsFromPEM(caData) {
-			if r.caPool == nil {
-				return errors.Errorf("failed to parse cluster-proxy CA bundle %s", r.caFile)
-			}
-			caChanged = false
-		} else {
-			caPool = pool
+			// keep the last good cert
+		case !certsEqual(r.cert, &loaded):
+			r.cert = &loaded
+			rotated = true
 		}
 	}
 
-	certChanged := !certsEqual(r.cert, cert)
-	had := r.caPool != nil || r.cert != nil
-
-	r.caData = caData
-	r.caPool = caPool
-	r.cert = cert
-
-	if had && (caChanged || certChanged) && r.onRotate != nil {
-		r.onRotate()
-	}
-	return nil
+	return rotated, nil
 }
 
 // certsEqual reports whether two client certificates carry the same leaf chain.

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -2,12 +2,13 @@ package v1alpha1
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -28,9 +29,11 @@ import (
 // scoped to context.Background() so the connection it backs can be pooled.
 //
 // The client TLS material is read once here (when the dialer is built) rather
-// than on every dial, so it does not sit on the connection hot path. As a
-// consequence a rotation of the cluster-proxy client cert/key requires a
-// process restart to take effect.
+// than on every dial, so it does not sit on the connection hot path. The client
+// cert/key are reloaded lazily through tls.Config.GetClientCertificate when the
+// files change, so a rotation of the cluster-proxy client cert/key is picked up
+// on the next tunnel without a process restart. (Rotation of the CA bundle still
+// requires a restart.)
 var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
 	proxyAddress := net.JoinHostPort(config.ClusterProxyHost, strconv.Itoa(config.ClusterProxyPort))
 	tlsCfg, err := util.GetClientTLSConfig(
@@ -41,6 +44,13 @@ var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
 		nil)
 	if err != nil {
 		return nil, err
+	}
+	// Reload the client cert/key on rotation instead of pinning the copy read
+	// above for the lifetime of the process.
+	if config.ClusterProxyCertFile != "" || config.ClusterProxyKeyFile != "" {
+		reloader := &reloadingClientCert{certFile: config.ClusterProxyCertFile, keyFile: config.ClusterProxyKeyFile}
+		tlsCfg.Certificates = nil
+		tlsCfg.GetClientCertificate = reloader.getClientCertificate
 	}
 	transportCreds := grpccredentials.NewTLS(tlsCfg)
 	return func(ctx context.Context, _, addr string) (net.Conn, error) {
@@ -59,60 +69,127 @@ var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
 	}, nil
 }
 
+// reloadingClientCert loads the cluster-proxy client cert/key from disk and
+// re-reads them when the files change, so cert rotation does not require a
+// process restart. tls.Config calls getClientCertificate once per handshake.
+type reloadingClientCert struct {
+	certFile, keyFile string
+
+	mu      sync.Mutex
+	cert    *tls.Certificate
+	modCert time.Time
+	modKey  time.Time
+}
+
+func (r *reloadingClientCert) getClientCertificate(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	certInfo, err := os.Stat(r.certFile)
+	if err != nil {
+		return nil, err
+	}
+	keyInfo, err := os.Stat(r.keyFile)
+	if err != nil {
+		return nil, err
+	}
+	if r.cert == nil || certInfo.ModTime().After(r.modCert) || keyInfo.ModTime().After(r.modKey) {
+		cert, err := tls.LoadX509KeyPair(r.certFile, r.keyFile)
+		if err != nil {
+			return nil, err
+		}
+		r.cert = &cert
+		r.modCert = certInfo.ModTime()
+		r.modKey = keyInfo.ModTime()
+	}
+	return r.cert, nil
+}
+
 var (
-	clusterProxyDialHolderOnce sync.Once
+	clusterProxyDialHolderMu   sync.Mutex
 	clusterProxyDialHolderInst *k8stransport.DialHolder
-	clusterProxyDialHolderErr  error
 )
 
 // ClusterProxyDialHolder returns a process-wide stable DialHolder so client-go's
 // transport cache can reuse one pooled http.Transport per cluster credential.
+//
+// The holder is built lazily and only memoized on success, so a transient
+// failure (e.g. the cluster-proxy client certs not yet mounted at startup) is
+// retried on the next call instead of bricking cluster-proxy until a restart.
 func ClusterProxyDialHolder() (*k8stransport.DialHolder, error) {
-	clusterProxyDialHolderOnce.Do(func() {
-		dial, err := DialerGetter(context.Background())
-		if err != nil {
-			clusterProxyDialHolderErr = err
-			return
-		}
-		clusterProxyDialHolderInst = &k8stransport.DialHolder{Dial: dial}
-	})
-	return clusterProxyDialHolderInst, clusterProxyDialHolderErr
+	clusterProxyDialHolderMu.Lock()
+	defer clusterProxyDialHolderMu.Unlock()
+	if clusterProxyDialHolderInst != nil {
+		return clusterProxyDialHolderInst, nil
+	}
+	dial, err := DialerGetter(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	clusterProxyDialHolderInst = &k8stransport.DialHolder{Dial: dial}
+	return clusterProxyDialHolderInst, nil
 }
 
-var clusterProxyUpgradeTransports sync.Map // credential key -> *http.Transport
+type clusterProxyUpgradeEntry struct {
+	credKey   string
+	transport *http.Transport
+}
 
-// ClusterProxyUpgradeTransport returns a process-wide pooled upgrade (SPDY)
-// transport for the given credential, so exec/attach/port-forward requests reuse
-// one http.Transport per credential instead of allocating a fresh one per request.
-// The shared cluster-proxy DialHolder dial routes each connection to the right
-// cluster by address, so a single transport is safe to share across clusters that
-// present the same TLS credential. Entries are keyed by the credential material
-// and are not evicted, mirroring client-go's own (unbounded) tlsTransportCache.
-func ClusterProxyUpgradeTransport(transportCfg *k8stransport.Config, tlsConfig *tls.Config, dial k8snet.DialFunc) *http.Transport {
-	key := clusterProxyUpgradeKey(transportCfg)
-	if v, ok := clusterProxyUpgradeTransports.Load(key); ok {
-		return v.(*http.Transport)
+var (
+	clusterProxyUpgradeMu         sync.Mutex
+	clusterProxyUpgradeTransports = map[string]*clusterProxyUpgradeEntry{}
+)
+
+// ClusterProxyUpgradeTransport returns a pooled upgrade (SPDY) transport for the
+// given cluster, so exec/attach/port-forward requests reuse one http.Transport
+// per cluster instead of allocating a fresh one per request. The shared
+// cluster-proxy DialHolder dial routes each connection to the right cluster by
+// address. The cache is keyed by cluster name and is bounded by the number of
+// clusters: when a cluster's credential rotates, the stale transport's idle
+// connections are dropped and it is replaced rather than accumulated.
+func ClusterProxyUpgradeTransport(clusterName string, transportCfg *k8stransport.Config, dial k8snet.DialFunc) (*http.Transport, error) {
+	credKey := clusterProxyUpgradeKey(transportCfg)
+
+	clusterProxyUpgradeMu.Lock()
+	defer clusterProxyUpgradeMu.Unlock()
+	if entry, ok := clusterProxyUpgradeTransports[clusterName]; ok {
+		if entry.credKey == credKey {
+			return entry.transport, nil
+		}
+		// Credential rotated: drop the stale transport's pooled connections
+		// before replacing it so we do not leak idle tunnels.
+		entry.transport.CloseIdleConnections()
+	}
+
+	tlsConfig, err := k8stransport.TLSConfigFor(transportCfg)
+	if err != nil {
+		return nil, err
 	}
 	t := k8snet.SetOldTransportDefaults(&http.Transport{
 		TLSClientConfig: tlsConfig,
 		DialContext:     dial,
 	})
-	actual, _ := clusterProxyUpgradeTransports.LoadOrStore(key, t)
-	return actual.(*http.Transport)
+	clusterProxyUpgradeTransports[clusterName] = &clusterProxyUpgradeEntry{credKey: credKey, transport: t}
+	return t, nil
 }
 
-// clusterProxyUpgradeKey derives a cache key from the TLS credential material,
-// matching the fields client-go's transport cache keys on.
+// clusterProxyUpgradeKey is a cheap fingerprint of the TLS credential material,
+// used only to detect when a cluster's credential has rotated. It is a private
+// hash, not a reimplementation of client-go's transport-cache key.
 func clusterProxyUpgradeKey(c *k8stransport.Config) string {
-	return strings.Join([]string{
-		strconv.FormatBool(c.TLS.Insecure),
-		c.TLS.ServerName,
-		string(c.TLS.CAData),
-		string(c.TLS.CertData),
-		string(c.TLS.KeyData),
-		c.TLS.CertFile,
-		c.TLS.KeyFile,
-	}, "\x00")
+	h := sha256.New()
+	writeField := func(b []byte) {
+		_, _ = h.Write(b)
+		_, _ = h.Write([]byte{0})
+	}
+	writeField([]byte(strconv.FormatBool(c.TLS.Insecure)))
+	writeField([]byte(c.TLS.ServerName))
+	writeField(c.TLS.CAData)
+	writeField(c.TLS.CertData)
+	writeField(c.TLS.KeyData)
+	writeField([]byte(c.TLS.CertFile))
+	writeField([]byte(c.TLS.KeyFile))
+	return string(h.Sum(nil))
 }
 
 func NewConfigFromCluster(ctx context.Context, c *ClusterGateway) (*restclient.Config, error) {

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -2,10 +2,12 @@ package v1alpha1
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -75,6 +77,42 @@ func ClusterProxyDialHolder() (*k8stransport.DialHolder, error) {
 		clusterProxyDialHolderInst = &k8stransport.DialHolder{Dial: dial}
 	})
 	return clusterProxyDialHolderInst, clusterProxyDialHolderErr
+}
+
+var clusterProxyUpgradeTransports sync.Map // credential key -> *http.Transport
+
+// ClusterProxyUpgradeTransport returns a process-wide pooled upgrade (SPDY)
+// transport for the given credential, so exec/attach/port-forward requests reuse
+// one http.Transport per credential instead of allocating a fresh one per request.
+// The shared cluster-proxy DialHolder dial routes each connection to the right
+// cluster by address, so a single transport is safe to share across clusters that
+// present the same TLS credential. Entries are keyed by the credential material
+// and are not evicted, mirroring client-go's own (unbounded) tlsTransportCache.
+func ClusterProxyUpgradeTransport(transportCfg *k8stransport.Config, tlsConfig *tls.Config, dial k8snet.DialFunc) *http.Transport {
+	key := clusterProxyUpgradeKey(transportCfg)
+	if v, ok := clusterProxyUpgradeTransports.Load(key); ok {
+		return v.(*http.Transport)
+	}
+	t := k8snet.SetOldTransportDefaults(&http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialContext:     dial,
+	})
+	actual, _ := clusterProxyUpgradeTransports.LoadOrStore(key, t)
+	return actual.(*http.Transport)
+}
+
+// clusterProxyUpgradeKey derives a cache key from the TLS credential material,
+// matching the fields client-go's transport cache keys on.
+func clusterProxyUpgradeKey(c *k8stransport.Config) string {
+	return strings.Join([]string{
+		strconv.FormatBool(c.TLS.Insecure),
+		c.TLS.ServerName,
+		string(c.TLS.CAData),
+		string(c.TLS.CertData),
+		string(c.TLS.KeyData),
+		c.TLS.CertFile,
+		c.TLS.KeyFile,
+	}, "\x00")
 }
 
 func NewConfigFromCluster(ctx context.Context, c *ClusterGateway) (*restclient.Config, error) {

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -14,34 +15,60 @@ import (
 	"google.golang.org/grpc/keepalive"
 	k8snet "k8s.io/apimachinery/pkg/util/net"
 	restclient "k8s.io/client-go/rest"
+	k8stransport "k8s.io/client-go/transport"
 	konnectivity "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
 	"sigs.k8s.io/apiserver-network-proxy/pkg/util"
 
 	"github.com/kluster-manager/cluster-gateway/pkg/config"
 )
 
-var DialerGetter = func(ctx context.Context) (k8snet.DialFunc, error) {
-	tlsCfg, err := util.GetClientTLSConfig(
-		config.ClusterProxyCAFile,
-		config.ClusterProxyCertFile,
-		config.ClusterProxyKeyFile,
-		config.ClusterProxyHost,
-		nil)
-	if err != nil {
-		return nil, err
-	}
-	dialerTunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
-		ctx,
-		net.JoinHostPort(config.ClusterProxyHost, strconv.Itoa(config.ClusterProxyPort)),
-		grpc.WithTransportCredentials(grpccredentials.NewTLS(tlsCfg)),
-		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time: time.Second * 5,
-		}),
-	)
-	if err != nil {
-		return nil, err
-	}
-	return dialerTunnel.DialContext, nil
+// DialerGetter returns a dialer that creates a konnectivity tunnel on demand,
+// scoped to context.Background() so the connection it backs can be pooled.
+var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
+	proxyAddress := net.JoinHostPort(config.ClusterProxyHost, strconv.Itoa(config.ClusterProxyPort))
+	return func(ctx context.Context, _, addr string) (net.Conn, error) {
+		tlsCfg, err := util.GetClientTLSConfig(
+			config.ClusterProxyCAFile,
+			config.ClusterProxyCertFile,
+			config.ClusterProxyKeyFile,
+			config.ClusterProxyHost,
+			nil)
+		if err != nil {
+			return nil, err
+		}
+		dialerTunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
+			context.Background(),
+			proxyAddress,
+			grpc.WithTransportCredentials(grpccredentials.NewTLS(tlsCfg)),
+			grpc.WithKeepaliveParams(keepalive.ClientParameters{
+				Time: time.Second * 5,
+			}),
+		)
+		if err != nil {
+			return nil, err
+		}
+		return dialerTunnel.DialContext(ctx, "tcp", addr)
+	}, nil
+}
+
+var (
+	clusterProxyDialHolderOnce sync.Once
+	clusterProxyDialHolderInst *k8stransport.DialHolder
+	clusterProxyDialHolderErr  error
+)
+
+// ClusterProxyDialHolder returns a process-wide stable DialHolder so client-go's
+// transport cache can reuse one pooled http.Transport per cluster credential.
+func ClusterProxyDialHolder() (*k8stransport.DialHolder, error) {
+	clusterProxyDialHolderOnce.Do(func() {
+		dial, err := DialerGetter(context.Background())
+		if err != nil {
+			clusterProxyDialHolderErr = err
+			return
+		}
+		clusterProxyDialHolderInst = &k8stransport.DialHolder{Dial: dial}
+	})
+	return clusterProxyDialHolderInst, clusterProxyDialHolderErr
 }
 
 func NewConfigFromCluster(ctx context.Context, c *ClusterGateway) (*restclient.Config, error) {

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -133,7 +133,15 @@ func ClusterProxyDialHolder() (*k8stransport.DialHolder, error) {
 type clusterProxyUpgradeEntry struct {
 	credKey   string
 	transport *http.Transport
+	lastUsed  time.Time
 }
+
+// clusterProxyUpgradeTransportCap caps the upgrade-transport cache so it cannot
+// grow without bound. Entries are keyed by cluster name and there is no
+// cluster-deletion hook at this layer, so a fleet whose cluster names churn over
+// time would otherwise accumulate one transport per name forever. Far more than
+// any realistic live cluster count, this only evicts genuinely stale entries.
+const clusterProxyUpgradeTransportCap = 1024
 
 var (
 	clusterProxyUpgradeMu         sync.Mutex
@@ -144,9 +152,10 @@ var (
 // given cluster, so exec/attach/port-forward requests reuse one http.Transport
 // per cluster instead of allocating a fresh one per request. The shared
 // cluster-proxy DialHolder dial routes each connection to the right cluster by
-// address. The cache is keyed by cluster name and is bounded by the number of
-// clusters: when a cluster's credential rotates, the stale transport's idle
-// connections are dropped and it is replaced rather than accumulated.
+// address. The cache is keyed by cluster name; when a cluster's credential
+// rotates the stale transport's idle connections are dropped and it is replaced,
+// and the cache is bounded to clusterProxyUpgradeTransportCap entries (evicting
+// the least-recently-used) so it cannot grow without bound under name churn.
 func ClusterProxyUpgradeTransport(clusterName string, transportCfg *k8stransport.Config, dial k8snet.DialFunc) (*http.Transport, error) {
 	credKey := clusterProxyUpgradeKey(transportCfg)
 
@@ -154,6 +163,7 @@ func ClusterProxyUpgradeTransport(clusterName string, transportCfg *k8stransport
 	defer clusterProxyUpgradeMu.Unlock()
 	if entry, ok := clusterProxyUpgradeTransports[clusterName]; ok {
 		if entry.credKey == credKey {
+			entry.lastUsed = time.Now()
 			return entry.transport, nil
 		}
 		// Credential rotated: drop the stale transport's pooled connections
@@ -169,8 +179,32 @@ func ClusterProxyUpgradeTransport(clusterName string, transportCfg *k8stransport
 		TLSClientConfig: tlsConfig,
 		DialContext:     dial,
 	})
-	clusterProxyUpgradeTransports[clusterName] = &clusterProxyUpgradeEntry{credKey: credKey, transport: t}
+	evictStaleUpgradeTransportsLocked(clusterName)
+	clusterProxyUpgradeTransports[clusterName] = &clusterProxyUpgradeEntry{credKey: credKey, transport: t, lastUsed: time.Now()}
 	return t, nil
+}
+
+// evictStaleUpgradeTransportsLocked drops the least-recently-used entries (other
+// than keepName, which is about to be (re)inserted) until there is room for one
+// more. Callers hold clusterProxyUpgradeMu.
+func evictStaleUpgradeTransportsLocked(keepName string) {
+	for len(clusterProxyUpgradeTransports) >= clusterProxyUpgradeTransportCap {
+		var oldestName string
+		var oldest time.Time
+		for name, entry := range clusterProxyUpgradeTransports {
+			if name == keepName {
+				continue
+			}
+			if oldestName == "" || entry.lastUsed.Before(oldest) {
+				oldestName, oldest = name, entry.lastUsed
+			}
+		}
+		if oldestName == "" {
+			return
+		}
+		clusterProxyUpgradeTransports[oldestName].transport.CloseIdleConnections()
+		delete(clusterProxyUpgradeTransports, oldestName)
+	}
 }
 
 // clusterProxyUpgradeKey is a cheap fingerprint of the TLS credential material,

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -234,11 +234,17 @@ func NewConfigFromCluster(ctx context.Context, c *ClusterGateway) (*restclient.C
 		cfg.Host = c.Name // the same as the cluster name
 		cfg.Insecure = true
 		cfg.CAData = nil
-		dail, err := DialerGetter(ctx)
+		// Reuse the process-wide pooled dialer instead of building one (and
+		// reading the client TLS material from disk) on every request. ServeHTTP
+		// injects the same shared DialHolder, so a per-request dialer here would
+		// only be built and discarded; routing every consumer of this config
+		// through the pooled holder also keeps connection pooling from depending
+		// on which caller built the transport.
+		holder, err := ClusterProxyDialHolder()
 		if err != nil {
 			return nil, err
 		}
-		cfg.Dial = dail
+		cfg.Dial = holder.Dial
 	}
 	// setting up credentials
 	switch c.Spec.Access.Credential.Type {

--- a/pkg/apis/gateway/v1alpha1/transport.go
+++ b/pkg/apis/gateway/v1alpha1/transport.go
@@ -21,6 +21,7 @@ import (
 	k8snet "k8s.io/apimachinery/pkg/util/net"
 	restclient "k8s.io/client-go/rest"
 	k8stransport "k8s.io/client-go/transport"
+	"k8s.io/client-go/util/connrotation"
 	konnectivity "sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client"
 
 	"github.com/kluster-manager/cluster-gateway/pkg/config"
@@ -49,7 +50,11 @@ var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
 	if err != nil {
 		return nil, err
 	}
-	return func(ctx context.Context, _, addr string) (net.Conn, error) {
+	// Route every konnectivity tunnel through a connrotation.Dialer so that on a
+	// cert/CA rotation we can close the pooled tunnels and force them to re-dial
+	// with the new material, instead of leaving warm connections authenticating
+	// with the old credential until they idle out.
+	connDialer := connrotation.NewDialer(func(ctx context.Context, _, addr string) (net.Conn, error) {
 		dialerTunnel, err := konnectivity.CreateSingleUseGrpcTunnel(
 			context.Background(),
 			proxyAddress,
@@ -62,6 +67,10 @@ var DialerGetter = func(_ context.Context) (k8snet.DialFunc, error) {
 			return nil, err
 		}
 		return dialerTunnel.DialContext(ctx, "tcp", addr)
+	})
+	reloader.setOnRotate(connDialer.CloseAll)
+	return func(ctx context.Context, _, addr string) (net.Conn, error) {
+		return connDialer.DialContext(ctx, "tcp", addr)
 	}, nil
 }
 
@@ -116,6 +125,14 @@ func (r *reloadingTLS) tlsConfig() *tls.Config {
 		cfg.Certificates = []tls.Certificate{*r.cert}
 	}
 	return cfg
+}
+
+// setOnRotate registers a callback invoked when the cert or CA changes after the
+// initial load. It is set after construction so the initial load does not fire it.
+func (r *reloadingTLS) setOnRotate(fn func()) {
+	r.mu.Lock()
+	r.onRotate = fn
+	r.mu.Unlock()
 }
 
 // reloadLocked re-reads the CA and cert/key files. Callers hold r.mu. On a read

--- a/pkg/apis/gateway/v1alpha1/transport_test.go
+++ b/pkg/apis/gateway/v1alpha1/transport_test.go
@@ -29,6 +29,9 @@ func TestClusterRestConfigConversion(t *testing.T) {
 	DialerGetter = func(ctx context.Context) (k8snet.DialFunc, error) {
 		return testDialFunc, nil
 	}
+	// Reset the process-wide cluster-proxy caches so the overridden DialerGetter
+	// is the one memoized, independent of any earlier test in the package.
+	resetClusterProxyState()
 	cases := []struct {
 		name           string
 		clusterGateway *ClusterGateway
@@ -239,4 +242,17 @@ func TestClusterRestConfigConversion(t *testing.T) {
 		})
 	}
 
+}
+
+// resetClusterProxyState clears the process-wide cluster-proxy caches so a test
+// that overrides DialerGetter is not affected by state memoized by an earlier
+// test in the package.
+func resetClusterProxyState() {
+	clusterProxyDialHolderMu.Lock()
+	clusterProxyDialHolderInst = nil
+	clusterProxyDialHolderMu.Unlock()
+
+	clusterProxyUpgradeMu.Lock()
+	clusterProxyUpgradeTransports = map[string]*clusterProxyUpgradeEntry{}
+	clusterProxyUpgradeMu.Unlock()
 }


### PR DESCRIPTION
## Problem

Every proxied request to a `ClusterGateway` built a brand-new `http.Transport` (via `restclient.TransportFor`) and, for cluster-proxy endpoints, a fresh konnectivity gRPC tunnel — none of which were pooled or reused. Under sustained proxy / exec / attach / port-forward traffic the process steadily accumulated transports, TLS state, and gRPC connections, leaking memory and connections/file descriptors.

This PR pools the cluster-proxy transports so one `http.Transport` is reused per credential instead of per request, then hardens the pooling, the credential rotation, and the cache lifecycle in response to two rounds of review.

Scope is limited to `transport.go`, `clustergateway_proxy.go`, and a `go.mod`/`go.sum` tidy. (The unit-test repair and CI fixes that surfaced alongside this work merged separately in #21; GitHub Actions SHA-pinning merged in #20.)

## Commits

### Initial pooling

1. **Fix memory leak** — Create konnectivity tunnels through a process-wide stable `DialHolder` (`ClusterProxyDialHolder`) so client-go's transport cache can reuse one pooled `http.Transport` per credential across requests instead of allocating one per request.
2. **Read cluster-proxy TLS material once instead of per dial** — Hoist `GetClientTLSConfig` (which reads CA/cert/key files from disk) out of the per-dial closure so the TLS material and gRPC transport credentials are loaded once per process for the pooled `DialHolder`.
3. **Fail closed when the cluster-proxy dial holder is unavailable** — Surface the error instead of silently falling back to `restclient.TransportFor(cfg)` (which would reintroduce the per-request transport / the leak).
4. **Build the transport config once per proxied request** — Compute the transport config once in `ServeHTTP` and pass it in, reusing it for the TLS and upgrader wrappers; `transport.New(transportCfg)` is equivalent to the prior `restclient.TransportFor(cfg)` for the non-cluster-proxy path.
5. **Pool the cluster-proxy SPDY upgrade transport per credential** — Cache the exec/attach/port-forward `http.Transport` instead of rebuilding it on every request; non-cluster-proxy endpoints keep the per-request transport.

### Review hardening

6. **Address review feedback on cluster-proxy transport pooling** — Build the dial holder lazily under a mutex and memoize only on success (so a transient startup failure retries instead of bricking cluster-proxy until a restart); resolve the holder once in `ServeHTTP` and fail closed consistently for both the proxied and upgrade transports; key the upgrade-transport cache by cluster name with replace-on-rotation; apply `cfg.Proxy` to the non-cluster-proxy upgrade transport; build the upgrade `tls.Config` only on the non-pooled path.
7. **Reuse the pooled dial holder in NewConfigFromCluster** — Stop calling `DialerGetter` (and re-reading the client TLS material) on every cluster-proxy request only to have `ServeHTTP` discard the result; resolve `cfg.Dial` from the pooled holder so no files are touched per request and every consumer of the config gets the pooled dialer.
8. **Drop the unreachable dial-holder nil check** — `ClusterProxyDialHolder` never returns `(nil, nil)`; remove the dead branch.
9. **Bound the cluster-proxy upgrade-transport cache** — There is no cluster-deletion hook at this layer, so cap the cache and evict the least-recently-used entry (closing its idle connections) to prevent unbounded growth under cluster-name churn.
10. **Reload cluster-proxy cert and CA by content with a fallback** — Replace the mtime-based client-cert-only reloader with one that reloads both the CA bundle and the client cert/key, throttled and compared by content (off the per-handshake path), keeping the last good material on a transient read error; each new tunnel gets a fresh `tls.Config`, so CA rotation no longer requires a restart.
11. **Close pooled konnectivity tunnels on credential rotation** — Route tunnel dials through client-go's `connrotation.Dialer` and call `CloseAll` when the cert/CA content changes, so warm pooled tunnels re-dial with the new material instead of clinging to the old credential until they idle out.

## Verification

- `go build ./pkg/... ./cmd/...`, `make vet`, and `go test ./pkg/apis/gateway/v1alpha1/` all pass on the rebased branch.

## Notes / trade-offs

- Client cert/key **and** CA rotation are now picked up live (no restart), and existing pooled tunnels are dropped on rotation so they re-handshake with the new material.