### PR TITLE
Pin all GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
           images: |
             ghcr.io/kluster-manager/cluster-gateway
@@ -48,7 +48,7 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@0a97817b6ade9f46837855d676c4cca3a2471fc9 # v4.2.1
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,13 +46,13 @@ jobs:
         with:
           submodules: true
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-pkg-
       - name: install Kubebuilder
-        uses: RyanSiu1995/kubebuilder-action@v1.2
+        uses: RyanSiu1995/kubebuilder-action@0bb0adef70bbf9c58f6f63c180387b4bdaf102f7 # v1.2
         with:
           version: 3.1.0
           kubebuilderOnly: false
@@ -60,7 +60,7 @@ jobs:
       - name: Run Make test
         run: make test
       - name: Upload coverage report
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: cover.out
@@ -86,7 +86,7 @@ jobs:
         with:
           submodules: true
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
@@ -125,7 +125,7 @@ jobs:
         with:
           submodules: true
       - name: Cache Go Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@8492260343ad570701412c2f464a5877dc76bace # v2
         with:
           path: .work/pkg
           key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -123,7 +123,7 @@ jobs:
           fetch-depth: 0
           path: go/src/ghcr.io/kluster-manager/cluster-gateway
       - name: setup helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
       - name: chart package
         run: |
           mkdir -p release
@@ -132,7 +132,7 @@ jobs:
           helm package ../charts/addon-manager/
           popd
       - name: publish release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           tag: ${{ needs.env.outputs.RELEASE_VERSION }}
           artifacts: "go/src/ghcr.io/kluster-manager/cluster-gateway/release/*.tgz"
@@ -140,7 +140,7 @@ jobs:
           allowUpdates: true
 #      lack secrets.PAT_TOKEN from ocm, commented now
 #      - name: submit charts to OCM chart repo
-#        uses: actions/github-script@v6
+#        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
 #        with:
 #          debug: ${{ secrets.ACTIONS_RUNNER_DEBUG }}
 #          github-token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
Several workflow steps still referenced mutable tags. Pin each remaining action to the full-length commit SHA the tag currently resolves to, keeping the version as a trailing comment so a moved tag cannot change what runs in CI.

Pinned in this PR:

| Workflow | Action | Pinned SHA (`# version`) |
|----------|--------|--------------------------|
| `ci.yml` | `actions/cache` (×3) | `8492260343ad570701412c2f464a5877dc76bace` `# v2` |
| `ci.yml` | `RyanSiu1995/kubebuilder-action` | `0bb0adef70bbf9c58f6f63c180387b4bdaf102f7` `# v1.2` |
| `ci.yml` | `codecov/codecov-action` | `ab904c41d6ece82784817410c45d8b8c02684457` `# v3.1.6` |
| `build-image.yml` | `docker/metadata-action` | `818d4b7b91585d195f67373fd9cb0332e31a7175` `# v4.6.0` |
| `build-image.yml` | `docker/build-push-action` | `0a97817b6ade9f46837855d676c4cca3a2471fc9` `# v4.2.1` |
| `go-release.yml` | `azure/setup-helm` | `18bc76811624f360dbd7f18c2d4ecb32c7b87bab` `# v1.1` |
| `go-release.yml` | `ncipollo/release-action` | `339a81892b84b4eeb0f6e744e4574d79d0d9b8dd` `# v1.21.0` |
| `go-release.yml` | `actions/github-script` (commented block) | `d7906e4ad0b1822421a7e6a35d5ca353c962f410` `# v6.4.1` |

The remaining actions were already SHA-pinned. After this change every `uses:` reference resolves to a full 40-character commit SHA.